### PR TITLE
Added base energy consumption config options for crafting terminal and interface

### DIFF
--- a/src/main/java/org/cyclops/integratedcrafting/GeneralConfig.java
+++ b/src/main/java/org/cyclops/integratedcrafting/GeneralConfig.java
@@ -72,6 +72,18 @@ public class GeneralConfig extends DummyConfig {
     public static int maxPendingCraftingJobs = 256;
 
     /**
+     * The base energy usage for the crafting writer.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the crafting writer.", minimalValue = 0)
+    public static int craftingWriterBaseConsumption = 1;
+
+    /**
+     * The base energy usage for the crafting interface per crafting job being processed.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the crafting interface per crafting job being processed.", minimalValue = 0)
+    public static int interfaceCraftingBaseConsumption = 5;
+
+    /**
      * The type of this config.
      */
     public static ConfigurableType TYPE = ConfigurableType.DUMMY;

--- a/src/main/java/org/cyclops/integratedcrafting/part/PartTypeCraftingWriter.java
+++ b/src/main/java/org/cyclops/integratedcrafting/part/PartTypeCraftingWriter.java
@@ -2,6 +2,7 @@ package org.cyclops.integratedcrafting.part;
 
 import com.google.common.collect.Lists;
 import org.cyclops.cyclopscore.init.ModBase;
+import org.cyclops.integratedcrafting.GeneralConfig;
 import org.cyclops.integratedcrafting.IntegratedCrafting;
 import org.cyclops.integratedcrafting.part.aspect.CraftingAspects;
 import org.cyclops.integrateddynamics.IntegratedDynamics;
@@ -29,6 +30,11 @@ public class PartTypeCraftingWriter extends PartTypeWriteBase<PartTypeCraftingWr
     @Override
     public PartStateWriterBase<PartTypeCraftingWriter> constructDefaultState() {
         return new PartStateWriterBase<>(Aspects.REGISTRY.getAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWriterBase<PartTypeCraftingWriter> state) {
+        return GeneralConfig.craftingWriterBaseConsumption;
     }
 
     @Override

--- a/src/main/java/org/cyclops/integratedcrafting/part/PartTypeInterfaceCrafting.java
+++ b/src/main/java/org/cyclops/integratedcrafting/part/PartTypeInterfaceCrafting.java
@@ -108,7 +108,7 @@ public class PartTypeInterfaceCrafting extends PartTypeCraftingBase<PartTypeInte
 
     @Override
     public int getConsumptionRate(State state) {
-        return state.getCraftingJobHandler().getProcessingCraftingJobs().size() * 5;
+        return state.getCraftingJobHandler().getProcessingCraftingJobs().size() * GeneralConfig.interfaceCraftingBaseConsumption;
     }
 
     public IGuiContainerProvider getSettingsGuiProvider() {

--- a/src/main/resources/assets/integratedcrafting/lang/en_us.lang
+++ b/src/main/resources/assets/integratedcrafting/lang/en_us.lang
@@ -52,6 +52,14 @@ aspect.aspects.integratedcrafting.write.fluidstack.craft.info=Craft the given fl
 aspect.aspects.integratedcrafting.write.integer.craft.name=Craft Energy
 aspect.aspects.integratedcrafting.write.integer.craft.info=Craft the given energy amount
 
+## Config categories
+config.integratedcrafting.general=General settings
+config.integratedcrafting.general.tooltip=General settings
+
+## General Settings
+config.integratedcrafting.general.craftingWriterBaseConsumption=Crafting writer base consumption
+config.integratedcrafting.general.interfaceCraftingBaseConsumption=Crafting interface base consumption
+
 # ------ On the Dynamics of Integration contents ------
 
 info_book.integratedcrafting.section.main=Crafting


### PR DESCRIPTION
Interface energy consumption is per crafting job being processed, as it was before.