### PR TITLE
Fix formatting of some exception messages

### DIFF
--- a/src/main/java/org/cyclops/integratedcrafting/api/crafting/CraftingJob.java
+++ b/src/main/java/org/cyclops/integratedcrafting/api/crafting/CraftingJob.java
@@ -153,7 +153,7 @@ public class CraftingJob {
             }
             T remaining = new IngredientComponentStorageSlottedCollectionWrapper<>(new IngredientList<>(ingredientComponent, instances), Integer.MAX_VALUE, Integer.MAX_VALUE).insert(instance, false);
             if (!matcher.isEmpty(remaining)) {
-                throw new IllegalStateException(String.format("Unable to insert %s into the crafting job buffer, remaining: ", instances, remaining));
+                throw new IllegalStateException(String.format("Unable to insert %s into the crafting job buffer, remaining: %s", instances, remaining));
             }
         }
 

--- a/src/main/java/org/cyclops/integratedcrafting/core/CraftingHelpers.java
+++ b/src/main/java/org/cyclops/integratedcrafting/core/CraftingHelpers.java
@@ -1169,9 +1169,9 @@ public class CraftingHelpers {
                     for (T instance : inputInstances) {
                         T remaining = storage.insert(instance, false);
                         if (!matcher.isEmpty(remaining)) {
-                            throw new IllegalStateException("Extraction for a crafting recipe failed" +
+                            throw new IllegalStateException(String.format("Extraction for a crafting recipe failed " +
                                     "due to inconsistent insertion behaviour by destination in simulation " +
-                                    "and non-simulation: " + storage + ". Lost: " + remaining);
+                                    "and non-simulation: %s. Lost: %s", storage, remaining));
                         }
                     }
                 }
@@ -1609,9 +1609,9 @@ public class CraftingHelpers {
         for (T instance : failedInstances) {
             T remaining = storageFallback.insert(instance, false);
             if (!matcher.isEmpty(remaining)) {
-                throw new IllegalStateException("Insertion for a crafting recipe failed" +
+                throw new IllegalStateException(String.format("Insertion for a crafting recipe failed " +
                         "due to inconsistent insertion behaviour by destination in simulation " +
-                        "and non-simulation: " + capabilityProvider + ". Lost: " + instances);
+                        "and non-simulation: %s. Lost: %s", capabilityProvider, instances));
             }
         }
 


### PR DESCRIPTION
Two commits, can be squashed with summaries merged into one if really needed.

Hopefully these are the only files affected, github search wasn't too helpful in finding more but I tried. Might look into covering other repos too with this specific problem.