### PR TITLE
[1.20.1] Correct invalid accessTransformers entry in mods.toml

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -13,8 +13,8 @@ updateJSONURL="https://raw.githubusercontent.com/CyclopsMC/Versions/master/forge
 description='''
 Craft stuff in Integrated Dynamics networks.
 '''
-[[accessTransformers]]
-    file="META-INF/accesstransformer.cfg"
+accessTransformers = ["META-INF/accesstransformer.cfg"]
+
 [[dependencies.integratedcrafting]]
     modId="cyclopscore"
     mandatory=true


### PR DESCRIPTION
Although it is not yet merged, over at Forge we're adding support for multiple AT files. The neo format for ATs is not the same and should not have been backported in this manner, however I implemented a fallback in case of mods having what yours has, so it won't crash if an end user uses the latest build.

This PR corrects the toml to match our upcoming format and still remains compatible with all prior forge versions, as we did not originally have a toml entry for this.
See <https://github.com/MinecraftForge/MinecraftForge/pull/10786> for any additional information.